### PR TITLE
Translate README files to English and add Portuguese version for Nginx configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,49 @@
 # API Go Project
 
-Este projeto é uma API desenvolvida em Go, com suporte a banco de dados, autenticação e configuração de ambientes utilizando Docker e Nginx.
+This project is an API developed in Go, with support for database, authentication, and environment configuration using Docker and Nginx.
 
 ---
 
-## 📁 Estrutura do Projeto
+## 📁 Project Structure
 
-A estrutura do projeto está organizada da seguinte forma:
+The project structure is organized as follows:
 
-- **`config/`**: Configurações gerais do projeto (ex.: banco de dados, logger).
-- **`db/`**: Scripts SQL e migrações para o banco de dados.
-- **`handler/`**: Handlers responsáveis por gerenciar as requisições HTTP.
-- **`nginx/`**: Configurações do Nginx para desenvolvimento e produção.
-- **`repositories/`**: Implementações de acesso ao banco de dados.
-- **`router/`**: Configuração das rotas da API.
-- **`schemas/`**: Definições de schemas para validação de dados.
-- **`utils/`**: Utilitários como geração de tokens JWT.
+- **`config/`**: General project configurations (e.g., database, logger).
+- **`db/`**: SQL scripts and database migrations.
+- **`handler/`**: Handlers responsible for managing HTTP requests.
+- **`nginx/`**: Nginx configurations for development and production.
+- **`repositories/`**: Database access implementations.
+- **`router/`**: API route configuration.
+- **`schemas/`**: Data validation schemas definitions.
+- **`utils/`**: Utilities such as JWT token generation.
 
 ---
 
-## 🚀 Instruções de Uso
+## 🚀 Usage Instructions
 
-### 1. **Pré-requisitos**
-Certifique-se de ter os seguintes softwares instalados:
-- Docker e Docker Compose
+### 1. **Prerequisites**
+Make sure you have the following software installed:
+- Docker and Docker Compose
 
-### 2. **Configuração do Ambiente**
-1. Copie o arquivo `example.env` para `.env` e configure as variáveis de ambiente necessárias.
+### 2. **Environment Configuration**
+1. Copy the `example.env` file to `.env` and configure the necessary environment variables.
 
-Obs: Não é necessário rodar manualmente as migrações, pois o serviço `migrations` no `docker-compose.yml` está configurado para aplicar as migrações automaticamente ao iniciar o ambiente.
+Note: It is not necessary to manually run the migrations, as the `migrations` service in `docker-compose.yml` is configured to automatically apply migrations when starting the environment.
 
-### 3. **Subindo o Ambiente de Desenvolvimento**
-Execute o seguinte comando para iniciar o ambiente local:
+### 3. **Starting the Development Environment**
+Run the following command to start the local environment:
 ```bash
 docker-compose up -d --build
 ```
-Isso irá iniciar os serviços definidos no `docker-compose.override.yml`, incluindo a API e o Nginx.
+This will start the services defined in `docker-compose.override.yml`, including the API and Nginx.
 
-### 4. **Configurando SSL em produção**
-Para configurar SSL em produção, é preciso alterar o arquivo `nginx/templates/prod.conf.template` para ter apenas HTTP (porta 80) e configurar o Certbot para gerar os certificados SSL, sem redirecionar HTTP para HTTPS. Siga o exemplo em `nginx/conf.d/prod.conf.gen-cert`. Depois rode:
+### 4. **Configuring SSL in Production**
+To configure SSL in production, you need to modify the `nginx/templates/prod.conf.template` file to have only HTTP (port 80) and configure Certbot to generate SSL certificates without redirecting HTTP to HTTPS. Follow the example in `nginx/conf.d/prod.conf.gen-cert`. Then run:
 ```bash
 mkdir -p certbot/www/.well-known/acme-challenge
 ```
 
-Ao rodar o comando abaixo, sertifique-se de substituir `seu-dominio.com` e `seu@email.com` pelos valores corretos. O comando irá gerar o certificado SSL utilizando o método de validação HTTP, onde o Certbot criará um arquivo de desafio no diretório especificado para comprovar a posse do domínio.
+When running the command below, make sure to replace `your-domain.com` and `your@email.com` with the correct values. The command will generate the SSL certificate using the HTTP validation method, where Certbot will create a challenge file in the specified directory to prove domain ownership.
 
 ```bash
 docker compose \
@@ -52,37 +52,37 @@ docker compose \
 run --rm certbot certonly \
 --webroot \
 --webroot-path=/var/www/certbot \
--d seu-dominio.com \
---email seu@email.com \
+-d your-domain.com \
+--email your@email.com \
 --agree-tos \
 --no-eff-email
 ```
 
-Depois de gerar o certificado, configure o Cron do servidor para renovar o certificado automaticamente, rodando o seguinte comando:
+After generating the certificate, configure the server's Cron to automatically renew the certificate by running the following command:
 ```bash
 crontab -e
 ```
-Depois adicione a seguinte linha para renovar o certificado diariamente, substituindo `/caminho` pelo caminho absoluto para o seu projeto. Este comando irá renovar o certificado e recarregar o Nginx para aplicar as mudanças:
+Then add the following line to renew the certificate daily, replacing `/path` with the absolute path to your project. This command will renew the certificate and reload Nginx to apply the changes:
 
 ```bash
-0 6 * * * docker compose -f /caminho/docker-compose.yml -f /caminho/docker-compose.prod.yml run --rm certbot renew && docker compose -f /caminho/docker-compose.yml -f /caminho/docker-compose.prod.yml exec nginx nginx -s reload
+0 6 * * * docker compose -f /path/docker-compose.yml -f /path/docker-compose.prod.yml run --rm certbot renew && docker compose -f /path/docker-compose.yml -f /path/docker-compose.prod.yml exec nginx nginx -s reload
 ```
 
-Obs: O horário do cron é em UTC, então ajuste o horário conforme necessário para garantir que a renovação ocorra em um horário conveniente. Neste caso, o cron está configurado para rodar diariamente às 6:00 UTC que equivale a 3:00 no horário de Brasília (BRT), horário de pouco tráfego.
+Note: The cron time is in UTC, so adjust the time as needed to ensure the renewal occurs at a convenient time. In this case, the cron is set to run daily at 6:00 UTC, which is equivalent to 3:00 AM Brasília time (BRT), a time of low traffic in Brazil.
 
-### 5. **Deploy em Produção**
-1. Configure as variáveis de ambiente no arquivo `.env`.
-2. Utilize os arquivos `docker-compose.yml` e `docker-compose.prod.yml` para subir os serviços:
+### 5. **Production Deployment**
+1. Configure the environment variables in the `.env` file.
+2. Use the `docker-compose.yml` and `docker-compose.prod.yml` files to start the services:
 ```bash
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 ```
 
 ---
 
-## 🛠️ Manutenção
-- Para aplicar migrações no banco de dados, utilize os scripts em `db/migrations/`.
+## 🛠️ Maintenance
+- To apply database migrations, use the scripts in `db/migrations/`.
 
 ---
 
-## 📌 Conclusão
-Este projeto foi desenvolvido com foco em escalabilidade e boas práticas, utilizando Go, Docker e Nginx para fornecer uma API robusta e segura.
+## 📌 Conclusion
+This project was developed with a focus on scalability and best practices, using Go, Docker, and Nginx to provide a robust and secure API.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,0 +1,88 @@
+# API Go Project
+
+Este projeto é uma API desenvolvida em Go, com suporte a banco de dados, autenticação e configuração de ambientes utilizando Docker e Nginx.
+
+---
+
+## 📁 Estrutura do Projeto
+
+A estrutura do projeto está organizada da seguinte forma:
+
+- **`config/`**: Configurações gerais do projeto (ex.: banco de dados, logger).
+- **`db/`**: Scripts SQL e migrações para o banco de dados.
+- **`handler/`**: Handlers responsáveis por gerenciar as requisições HTTP.
+- **`nginx/`**: Configurações do Nginx para desenvolvimento e produção.
+- **`repositories/`**: Implementações de acesso ao banco de dados.
+- **`router/`**: Configuração das rotas da API.
+- **`schemas/`**: Definições de schemas para validação de dados.
+- **`utils/`**: Utilitários como geração de tokens JWT.
+
+---
+
+## 🚀 Instruções de Uso
+
+### 1. **Pré-requisitos**
+Certifique-se de ter os seguintes softwares instalados:
+- Docker e Docker Compose
+
+### 2. **Configuração do Ambiente**
+1. Copie o arquivo `example.env` para `.env` e configure as variáveis de ambiente necessárias.
+
+Obs: Não é necessário rodar manualmente as migrações, pois o serviço `migrations` no `docker-compose.yml` está configurado para aplicar as migrações automaticamente ao iniciar o ambiente.
+
+### 3. **Subindo o Ambiente de Desenvolvimento**
+Execute o seguinte comando para iniciar o ambiente local:
+```bash
+docker-compose up -d --build
+```
+Isso irá iniciar os serviços definidos no `docker-compose.override.yml`, incluindo a API e o Nginx.
+
+### 4. **Configurando SSL em produção**
+Para configurar SSL em produção, é preciso alterar o arquivo `nginx/templates/prod.conf.template` para ter apenas HTTP (porta 80) e configurar o Certbot para gerar os certificados SSL, sem redirecionar HTTP para HTTPS. Siga o exemplo em `nginx/conf.d/prod.conf.gen-cert`. Depois rode:
+```bash
+mkdir -p certbot/www/.well-known/acme-challenge
+```
+
+Ao rodar o comando abaixo, sertifique-se de substituir `seu-dominio.com` e `seu@email.com` pelos valores corretos. O comando irá gerar o certificado SSL utilizando o método de validação HTTP, onde o Certbot criará um arquivo de desafio no diretório especificado para comprovar a posse do domínio.
+
+```bash
+docker compose \
+-f docker-compose.yml \
+-f docker-compose.prod.yml \
+run --rm certbot certonly \
+--webroot \
+--webroot-path=/var/www/certbot \
+-d seu-dominio.com \
+--email seu@email.com \
+--agree-tos \
+--no-eff-email
+```
+
+Depois de gerar o certificado, configure o Cron do servidor para renovar o certificado automaticamente, rodando o seguinte comando:
+```bash
+crontab -e
+```
+Depois adicione a seguinte linha para renovar o certificado diariamente, substituindo `/caminho` pelo caminho absoluto para o seu projeto. Este comando irá renovar o certificado e recarregar o Nginx para aplicar as mudanças:
+
+```bash
+0 6 * * * docker compose -f /caminho/docker-compose.yml -f /caminho/docker-compose.prod.yml run --rm certbot renew && docker compose -f /caminho/docker-compose.yml -f /caminho/docker-compose.prod.yml exec nginx nginx -s reload
+```
+
+Obs: O horário do cron é em UTC, então ajuste o horário conforme necessário para garantir que a renovação ocorra em um horário conveniente. Neste caso, o cron está configurado para rodar diariamente às 6:00 UTC que equivale a 3:00 no horário de Brasília (BRT), horário de pouco tráfego.
+
+### 5. **Deploy em Produção**
+1. Configure as variáveis de ambiente no arquivo `.env`.
+2. Utilize os arquivos `docker-compose.yml` e `docker-compose.prod.yml` para subir os serviços:
+```bash
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+```
+
+---
+
+## 🛠️ Manutenção
+- Para aplicar migrações no banco de dados, utilize os scripts em `db/migrations/`.
+
+---
+
+## 📌 Conclusão
+Este projeto foi desenvolvido com foco em escalabilidade e boas práticas, utilizando Go, Docker e Nginx para fornecer uma API robusta e segura.

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,10 +1,10 @@
 # Nginx Configuration
 
-Este diretório contém a configuração do Nginx para diferentes ambientes do projeto, seguindo uma abordagem profissional baseada em separação de responsabilidades.
+This directory contains the Nginx configuration for different project environments, following a professional approach based on separation of concerns.
 
 ---
 
-## 📁 Estrutura
+## 📁 Structure
 
 ```
 nginx/
@@ -17,90 +17,90 @@ nginx/
 
 ---
 
-## 🧠 Conceito geral
+## 🧠 General Concept
 
-A configuração foi separada em:
+The configuration is divided into:
 
-* **Configuração global** → `nginx.conf`
-* **Configuração por ambiente** → `dev` e `prod`
-* **Template dinâmico** → usado em produção com variáveis de ambiente
+* **Global configuration** → `nginx.conf`
+* **Environment-specific configuration** → `dev` and `prod`
+* **Dynamic template** → used in production with environment variables
 
 ---
 
-## ⚙️ nginx.conf (Configuração Global)
+## ⚙️ nginx.conf (Global Configuration)
 
-Arquivo base do Nginx.
+Base Nginx file.
 
-Responsável por:
+Responsible for:
 
-* definir workers
-* configurar `events`
-* configurar `http`
-* incluir os arquivos de configuração de servidores
+* defining workers
+* configuring `events`
+* configuring `http`
+* including server configuration files
 
-Exemplo:
+Example:
 
 ```
 include /etc/nginx/conf.d/*.conf;
 ```
 
-👉 Este arquivo **não contém blocos `server {}`**.
+👉 This file **does not contain `server {}` blocks**.
 
 ---
 
-## 🟢 Ambiente de Desenvolvimento (dev.conf)
+## 🟢 Development Environment (dev.conf)
 
-Localização:
+Location:
 
 ```
 nginx/conf.d/dev.conf
 ```
 
-Características:
+Characteristics:
 
-* Usa apenas HTTP (porta 80)
-* Sem HTTPS
-* Sem redirecionamento
-* Proxy direto para a API
+* Uses only HTTP (port 80)
+* No HTTPS
+* No redirection
+* Direct proxy to the API
 
-Objetivo:
+Purpose:
 
-* Simplicidade
-* Facilidade de desenvolvimento local
-* Evitar complexidade com certificados
+* Simplicity
+* Ease of local development
+* Avoid complexity with certificates
 
 ---
 
-## 🔴 Ambiente de Produção (prod.conf.template)
+## 🔴 Production Environment (prod.conf.template)
 
-Localização:
+Location:
 
 ```
 nginx/templates/prod.conf.template
 ```
 
-Características:
+Characteristics:
 
-* Usa HTTP (porta 80) + HTTPS (porta 443)
-* Redireciona HTTP → HTTPS
-* Utiliza certificados SSL
-* Usa variável de ambiente: `${NGINX_SERVER_NAME}`
+* Uses HTTP (port 80) + HTTPS (port 443)
+* Redirects HTTP → HTTPS
+* Uses SSL certificates
+* Uses environment variable: `${NGINX_SERVER_NAME}`
 
 ---
 
-## 🔄 Uso de Templates
+## 🔄 Template Usage
 
-Em produção, utilizamos o mecanismo de template do Docker:
+In production, we use Docker’s template mechanism:
 
 ```
 /etc/nginx/templates/*.template
 ```
 
-O container do Nginx:
+The Nginx container:
 
-1. Processa os arquivos `.template`
-2. Substitui variáveis de ambiente (envsubst)
-3. Gera arquivos finais em:
+1. Processes `.template` files
+2. Replaces environment variables (envsubst)
+3. Generates final files in:
 
 ```
 /etc/nginx/conf.d/
@@ -108,45 +108,45 @@ O container do Nginx:
 
 ---
 
-## 🔐 HTTPS e Certbot
+## 🔐 HTTPS and Certbot
 
-A configuração de produção inclui suporte a certificados gerados via Certbot.
+The production configuration includes support for certificates generated via Certbot.
 
-### Webroot utilizado:
+### Webroot used:
 
 ```
 /var/www/certbot
 ```
 
-### Desafio HTTP:
+### HTTP challenge:
 
 ```
 /.well-known/acme-challenge/
 ```
 
-Este caminho é necessário para validação do domínio.
+This path is required for domain validation.
 
 ---
 
-## 🚀 Fluxo de ativação do HTTPS
+## 🚀 HTTPS Activation Flow
 
-1. Subir Nginx apenas com HTTP
-2. Validar acesso ao webroot
-3. Gerar certificado com Certbot
-4. Ativar configuração HTTPS
-5. Reiniciar Nginx
+1. Start Nginx with HTTP only
+2. Validate access to the webroot
+3. Generate certificate with Certbot
+4. Enable HTTPS configuration
+5. Restart Nginx
 
 ---
 
-## 🔁 Renovação automática
+## 🔁 Automatic Renewal
 
-A renovação do certificado é feita via cron:
+Certificate renewal is handled via cron:
 
 ```
 certbot renew
 ```
 
-Após renovação, o Nginx deve ser recarregado:
+After renewal, Nginx must be reloaded:
 
 ```
 nginx -s reload
@@ -154,40 +154,38 @@ nginx -s reload
 
 ---
 
-## 🧩 Separação por ambiente
+## 🧩 Environment Separation
 
-| Ambiente | Arquivo                        | Características  |
-| -------- | ------------------------------ | ---------------- |
-| Dev      | `conf.d/dev.conf`              | HTTP simples     |
-| Prod     | `templates/prod.conf.template` | HTTPS + redirect |
-
----
-
-## 🎯 Benefícios desta arquitetura
-
-* Separação clara de ambientes
-* Reutilização do container Nginx
-* Configuração declarativa
-* Fácil manutenção
-* Escalável para múltiplos domínios
+| Environment | File                           | Characteristics  |
+| ----------- | ------------------------------ | ---------------- |
+| Dev         | `conf.d/dev.conf`              | Simple HTTP      |
+| Prod        | `templates/prod.conf.template` | HTTPS + redirect |
 
 ---
 
-## 💡 Observações
+## 🎯 Benefits of this Architecture
 
-* Variáveis de ambiente não funcionam diretamente em arquivos `.conf`
-* Devemos usar `.template` para permitir substituição via `envsubst`
-* Evitar duplicação de Dockerfiles
+* Clear separation of environments
+* Reusable Nginx container
+* Declarative configuration
+* Easy maintenance
+* Scalable for multiple domains
 
 ---
 
-## 📌 Conclusão
+## 💡 Notes
 
-Esta estrutura segue boas práticas de infraestrutura moderna, permitindo:
+* Environment variables do not work directly in `.conf` files
+* Use `.template` files to allow substitution via `envsubst`
+* Avoid duplicating Dockerfiles
 
-* desenvolvimento simples
-* deploy seguro
-* fácil replicação para outros projetos
+---
 
-```
-```
+## 📌 Conclusion
+
+This structure follows modern infrastructure best practices, enabling:
+
+* simple development
+* secure deployment
+* easy replication for other projects
+

--- a/nginx/README.pt-br.md
+++ b/nginx/README.pt-br.md
@@ -1,0 +1,193 @@
+# Nginx Configuration
+
+Este diretório contém a configuração do Nginx para diferentes ambientes do projeto, seguindo uma abordagem profissional baseada em separação de responsabilidades.
+
+---
+
+## 📁 Estrutura
+
+```
+nginx/
+├─ nginx.conf
+├─ conf.d/
+│  ├─ dev.conf
+├─ templates/
+│  └─ prod.conf.template
+```
+
+---
+
+## 🧠 Conceito geral
+
+A configuração foi separada em:
+
+* **Configuração global** → `nginx.conf`
+* **Configuração por ambiente** → `dev` e `prod`
+* **Template dinâmico** → usado em produção com variáveis de ambiente
+
+---
+
+## ⚙️ nginx.conf (Configuração Global)
+
+Arquivo base do Nginx.
+
+Responsável por:
+
+* definir workers
+* configurar `events`
+* configurar `http`
+* incluir os arquivos de configuração de servidores
+
+Exemplo:
+
+```
+include /etc/nginx/conf.d/*.conf;
+```
+
+👉 Este arquivo **não contém blocos `server {}`**.
+
+---
+
+## 🟢 Ambiente de Desenvolvimento (dev.conf)
+
+Localização:
+
+```
+nginx/conf.d/dev.conf
+```
+
+Características:
+
+* Usa apenas HTTP (porta 80)
+* Sem HTTPS
+* Sem redirecionamento
+* Proxy direto para a API
+
+Objetivo:
+
+* Simplicidade
+* Facilidade de desenvolvimento local
+* Evitar complexidade com certificados
+
+---
+
+## 🔴 Ambiente de Produção (prod.conf.template)
+
+Localização:
+
+```
+nginx/templates/prod.conf.template
+```
+
+Características:
+
+* Usa HTTP (porta 80) + HTTPS (porta 443)
+* Redireciona HTTP → HTTPS
+* Utiliza certificados SSL
+* Usa variável de ambiente: `${NGINX_SERVER_NAME}`
+
+---
+
+## 🔄 Uso de Templates
+
+Em produção, utilizamos o mecanismo de template do Docker:
+
+```
+/etc/nginx/templates/*.template
+```
+
+O container do Nginx:
+
+1. Processa os arquivos `.template`
+2. Substitui variáveis de ambiente (envsubst)
+3. Gera arquivos finais em:
+
+```
+/etc/nginx/conf.d/
+```
+
+---
+
+## 🔐 HTTPS e Certbot
+
+A configuração de produção inclui suporte a certificados gerados via Certbot.
+
+### Webroot utilizado:
+
+```
+/var/www/certbot
+```
+
+### Desafio HTTP:
+
+```
+/.well-known/acme-challenge/
+```
+
+Este caminho é necessário para validação do domínio.
+
+---
+
+## 🚀 Fluxo de ativação do HTTPS
+
+1. Subir Nginx apenas com HTTP
+2. Validar acesso ao webroot
+3. Gerar certificado com Certbot
+4. Ativar configuração HTTPS
+5. Reiniciar Nginx
+
+---
+
+## 🔁 Renovação automática
+
+A renovação do certificado é feita via cron:
+
+```
+certbot renew
+```
+
+Após renovação, o Nginx deve ser recarregado:
+
+```
+nginx -s reload
+```
+
+---
+
+## 🧩 Separação por ambiente
+
+| Ambiente | Arquivo                        | Características  |
+| -------- | ------------------------------ | ---------------- |
+| Dev      | `conf.d/dev.conf`              | HTTP simples     |
+| Prod     | `templates/prod.conf.template` | HTTPS + redirect |
+
+---
+
+## 🎯 Benefícios desta arquitetura
+
+* Separação clara de ambientes
+* Reutilização do container Nginx
+* Configuração declarativa
+* Fácil manutenção
+* Escalável para múltiplos domínios
+
+---
+
+## 💡 Observações
+
+* Variáveis de ambiente não funcionam diretamente em arquivos `.conf`
+* Devemos usar `.template` para permitir substituição via `envsubst`
+* Evitar duplicação de Dockerfiles
+
+---
+
+## 📌 Conclusão
+
+Esta estrutura segue boas práticas de infraestrutura moderna, permitindo:
+
+* desenvolvimento simples
+* deploy seguro
+* fácil replicação para outros projetos
+
+```
+```


### PR DESCRIPTION
Adds both Brazilian Portuguese (pt-BR) and English versions of the README files, with english being the default.