### PR TITLE
Refactor JWT authentication to use cookies instead of Authorization header

### DIFF
--- a/handler/AuthMiddleware.go
+++ b/handler/AuthMiddleware.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/AntonioHenriqueGF/apigo/utils"
 	"github.com/gin-gonic/gin"
@@ -11,24 +10,14 @@ import (
 // AuthenticationMiddleware checks if the user has a valid JWT token
 func AuthenticationMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		tokenString := c.GetHeader("Authorization")
-		if tokenString == "" {
+		cookie, err := c.Cookie("auth_token")
+		if err != nil {
 			sendError(c, http.StatusUnauthorized, "Missing authentication token")
 			c.Abort()
 			return
 		}
 
-		// The token should be prefixed with "Bearer "
-		tokenParts := strings.Split(tokenString, " ")
-		if len(tokenParts) != 2 || tokenParts[0] != "Bearer" {
-			sendError(c, http.StatusUnauthorized, "Invalid authentication token")
-			c.Abort()
-			return
-		}
-
-		tokenString = tokenParts[1]
-
-		claims, err := utils.VerifyToken(tokenString)
+		claims, err := utils.VerifyToken(cookie)
 		if err != nil {
 			sendError(c, http.StatusUnauthorized, "Invalid authentication token")
 			c.Abort()

--- a/handler/loginUser.go
+++ b/handler/loginUser.go
@@ -2,23 +2,18 @@ package handler
 
 import (
 	"net/http"
-	"strings"
 
+	"github.com/AntonioHenriqueGF/apigo/config"
 	"github.com/AntonioHenriqueGF/apigo/utils"
 	"github.com/gin-gonic/gin"
 )
 
+var (
+	hasHttps bool
+)
+
 func LoginUserHandler(ctx *gin.Context) {
 	request := LoginUserRequest{}
-
-	if tokenParts := strings.Split(ctx.GetHeader("Authorization"), " "); (len(tokenParts) == 2 && tokenParts[0] == "Bearer") &&
-		tokenParts[1] != "" {
-		_, err := utils.VerifyToken(tokenParts[1])
-		if err == nil {
-			ctx.JSON(http.StatusOK, gin.H{"token": tokenParts[1]})
-			return
-		}
-	}
 
 	if err := ctx.ShouldBindJSON(&request); err != nil {
 		logger.Errorf("failed to bind request: %v", err)
@@ -38,6 +33,18 @@ func LoginUserHandler(ctx *gin.Context) {
 		logger.Errorf("failed to generate token: %v", err)
 		sendError(ctx, http.StatusInternalServerError, "Error generating token")
 	}
+
+	hasHttps := config.GetEnv("DEVELOPMENT_MODE") != "true"
+	logger.Infof("Setting auth cookie with Secure=%v", hasHttps)
+
+	http.SetCookie(ctx.Writer, &http.Cookie{
+		Name:     "auth_token",
+		Value:    token, // O JWT gerado
+		HttpOnly: true,
+		Secure:   hasHttps, // Apenas para HTTPS
+		SameSite: http.SameSiteStrictMode,
+		Path:     "/",
+	})
 
 	sendBody(ctx, http.StatusOK, gin.H{"token": token})
 }


### PR DESCRIPTION
This pull request updates the authentication flow to use HTTP-only cookies for JWT tokens instead of the `Authorization` header. This improves security by preventing token access via JavaScript and streamlines token handling across requests. The most important changes are grouped below:

**Authentication Middleware Changes:**

* The `AuthenticationMiddleware` in `AuthMiddleware.go` now reads the JWT token from an `auth_token` cookie instead of the `Authorization` header, removing logic related to parsing the `Bearer` token format.
* The unused `strings` import was removed from `AuthMiddleware.go` as it is no longer needed for token parsing.

**Login Handler Changes:**

* The `LoginUserHandler` in `loginUser.go` now sets the JWT token as an HTTP-only, secure cookie (`auth_token`) on successful login, using the `Secure` flag based on the environment.
* The previous logic for checking and returning tokens from the `Authorization` header in `LoginUserHandler` was removed, as authentication now relies solely on cookies.
* The `strings` import was removed from `loginUser.go` since token parsing from headers is no longer performed.