### PR TITLE
Implement PATCH endpoint for updating posts with validation and error handling

### DIFF
--- a/handler/patchPost.go
+++ b/handler/patchPost.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/AntonioHenriqueGF/apigo/schemas"
+	"github.com/gin-gonic/gin"
+)
+
+func PatchPostHandler(ctx *gin.Context) {
+	idStr := ctx.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		sendError(ctx, http.StatusBadRequest, "invalid id")
+		return
+	}
+
+	request := PatchPostRequest{}
+
+	if err := ctx.BindJSON(&request); err != nil {
+		logger.Errorf("Error binding request body: %s", err.Error())
+		sendError(ctx, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := request.Validate(); err != nil {
+		logger.Errorf("validation error: %v", err.Error())
+		sendError(ctx, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	post := schemas.PostPatch{
+		ID:      id,
+		Title:   request.Title,
+		Content: request.Content,
+	}
+
+	if err := repo.Post.PatchPostById(ctx, post); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			sendError(ctx, http.StatusNotFound, "post not found")
+			return
+		}
+
+		logger.Errorf("Error patching post: %s", err.Error())
+		sendError(ctx, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	sendSuccess(ctx, "Post patched")
+}

--- a/handler/request.go
+++ b/handler/request.go
@@ -23,6 +23,10 @@ func errBadBodyFormating() error {
 	return fmt.Errorf("[payload] body is empty or malformed")
 }
 
+func errBadFieldFormating(name string) error {
+	return fmt.Errorf("[payload] field '%s' is empty or malformed", name)
+}
+
 type CreatePostRequest struct {
 	Title   string `json:"pst_title" binding:"required"`
 	Content string `json:"pst_content" binding:"required"`
@@ -103,6 +107,24 @@ func (r *UpdatePostRequest) Validate() error {
 	}
 	if r.Content == "" {
 		return errParamIsRequired("pst_content", "string")
+	}
+	return nil
+}
+
+type PatchPostRequest struct {
+	Title   *string `json:"pst_title"`
+	Content *string `json:"pst_content"`
+}
+
+func (r *PatchPostRequest) Validate() error {
+	if *r == (PatchPostRequest{}) {
+		return errBadBodyFormating()
+	}
+	if r.Title != nil && *r.Title == "" {
+		return errBadFieldFormating("pst_title")
+	}
+	if r.Content != nil && *r.Content == "" {
+		return errBadFieldFormating("pst_content")
 	}
 	return nil
 }

--- a/repositories/posts/posts.go
+++ b/repositories/posts/posts.go
@@ -14,4 +14,5 @@ type PostRepositorieInterface interface {
 	GetByID(ctx context.Context, id string) (*schemas.Post, error)
 	DeleteByID(ctx context.Context, id string) error
 	UpdatePostById(ctx context.Context, update schemas.PostUpdate) error
+	PatchPostById(ctx context.Context, update schemas.PostPatch) error
 }

--- a/repositories/posts/sqlx_impl.go
+++ b/repositories/posts/sqlx_impl.go
@@ -3,6 +3,8 @@ package posts
 import (
 	"context"
 	"database/sql"
+	"strings"
+	"time"
 
 	"github.com/AntonioHenriqueGF/apigo/schemas"
 	"github.com/jmoiron/sqlx"
@@ -103,4 +105,28 @@ func (p *postDbSqlx) UpdatePostById(ctx context.Context, update schemas.PostUpda
 	}
 
 	return nil
+}
+
+func (p *postDbSqlx) PatchPostById(ctx context.Context, update schemas.PostPatch) error {
+	query := "UPDATE posts SET "
+	builder := &UpdateBuilder{}
+
+	if update.Title != nil {
+		builder.Add("pst_title", *update.Title)
+	}
+
+	if update.Content != nil {
+		builder.Add("pst_content", *update.Content)
+	}
+
+	// Sempre atualizar a data de edição
+	builder.Add("pst_date_edit", time.Now())
+
+	query += strings.Join(builder.setParts, ", ")
+	query += " WHERE pst_id = ?"
+
+	builder.args = append(builder.args, update.ID)
+
+	_, err := p.writer.DB.ExecContext(ctx, query, builder.args...)
+	return err
 }

--- a/repositories/posts/updateBuilder.go
+++ b/repositories/posts/updateBuilder.go
@@ -1,0 +1,11 @@
+package posts
+
+type UpdateBuilder struct {
+	setParts []string
+	args     []any
+}
+
+func (u *UpdateBuilder) Add(field string, value any) {
+	u.setParts = append(u.setParts, field+" = ?")
+	u.args = append(u.args, value)
+}

--- a/router/routes.go
+++ b/router/routes.go
@@ -34,7 +34,7 @@ func InitializeRoutes(router *gin.Engine) {
 		protected.PUT("/post/:id", handler.UpdatePostHandler)
 
 		// Update Post
-		// protected.PATCH("/post/:id", handler.UpdatePostHandler)
+		protected.PATCH("/post/:id", handler.PatchPostHandler)
 
 		// Delete Post
 		protected.DELETE("/post/:id", handler.DeletePostHandler)

--- a/schemas/post.go
+++ b/schemas/post.go
@@ -11,8 +11,9 @@ type Post struct {
 }
 
 type PostPatch struct {
-	Title   string `json:"pst_title" db:"pst_title"`
-	Content string `json:"pst_content" db:"pst_content"`
+	ID      int     `json:"pst_id" db:"pst_id" binding:"required"`
+	Title   *string `json:"pst_title" db:"pst_title"`
+	Content *string `json:"pst_content" db:"pst_content"`
 }
 
 type PostUpdate struct {


### PR DESCRIPTION
This pull request introduces support for partial updates (PATCH) to posts in the API. The main changes include adding a new PATCH endpoint, request validation, repository method, and utility code to handle partial updates to post fields.

**API and Handler Enhancements:**

* Added a new `PatchPostHandler` in `handler/patchPost.go` to process PATCH requests for updating posts by ID, including request validation and error handling.
* Registered the PATCH endpoint `/post/:id` in the router, linking it to the new handler.

**Request and Validation Logic:**

* Introduced `PatchPostRequest` struct and its `Validate` method to allow partial updates of post fields, including logic to check for empty or malformed fields.
* Added a helper function `errBadFieldFormating` for more specific field validation error messages.

**Repository and Database Layer:**

* Added `PatchPostById` to the `PostRepositorieInterface` and implemented it in the SQLX repository to construct dynamic SQL update queries based on provided fields, using the new `UpdateBuilder` utility. 
* Updated the `PostPatch` schema to allow optional fields and require the post ID for partial updates.